### PR TITLE
Fix: UAttributesValidator now correctly handles the sink attribute.

### DIFF
--- a/src/main/kotlin/org/eclipse/uprotocol/transport/validate/UAttributesValidator.kt
+++ b/src/main/kotlin/org/eclipse/uprotocol/transport/validate/UAttributesValidator.kt
@@ -24,15 +24,10 @@
 
 package org.eclipse.uprotocol.transport.validate
 
-import org.eclipse.uprotocol.v1.UStatus;
-import org.eclipse.uprotocol.v1.UCode;
 import org.eclipse.uprotocol.uri.validator.UriValidator
 import org.eclipse.uprotocol.uuid.factory.UuidUtils
-import org.eclipse.uprotocol.v1.UAttributes
-import org.eclipse.uprotocol.v1.UMessageType
-import org.eclipse.uprotocol.v1.UUID
+import org.eclipse.uprotocol.v1.*
 import org.eclipse.uprotocol.validation.ValidationResult
-import java.util.*
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
@@ -231,7 +226,7 @@ abstract class UAttributesValidator {
         override fun validateSink(attributes: UAttributes): ValidationResult {
             return if (!attributes.hasSink()) {
                 ValidationResult.failure("Missing Sink")
-            } else UriValidator.validateRpcResponse(attributes.sink)
+            } else UriValidator.validateRpcMethod(attributes.sink)
         }
 
         /**
@@ -280,13 +275,10 @@ abstract class UAttributesValidator {
          * @return Returns a [ValidationResult] that is success or failed with a failure message.
          */
         override fun validateSink(attributes: UAttributes): ValidationResult {
-            Objects.requireNonNull(attributes, "UAttributes cannot be null.")
-            val result = UriValidator.validateRpcMethod(attributes.sink)
-            return if (result.isSuccess()) {
-                result
-            } else {
-                ValidationResult.failure("Missing Sink")
+            if (!attributes.hasSink() || attributes.sink === UUri.getDefaultInstance()) {
+                return ValidationResult.failure("Missing Sink")
             }
+            return UriValidator.validateRpcResponse(attributes.sink)
         }
 
         /**

--- a/src/test/kotlin/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.kt
+++ b/src/test/kotlin/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.kt
@@ -593,6 +593,60 @@ internal class UAttributesValidatorTest {
         val status: ValidationResult = validator.validate(attributes)
         assertEquals(ValidationResult.success(), status)
     }
+    @Test
+    @DisplayName("test_valid_request_methoduri_in_sink")
+    fun test_valid_request_methoduri_in_sink() {
+        val sink = LongUriSerializer.instance().deserialize("/test.service/1/rpc.method")
+        val attributes = UAttributesBuilder.request(UPriority.UPRIORITY_CS0, sink, 3000).build()
+        val validator = UAttributesValidator.getValidator(attributes)
+        assertEquals("UAttributesValidator.Request", validator.toString())
+        val status = validator.validate(attributes)
+        assertEquals(ValidationResult.success(), status)
+    }
+
+    @Test
+    @DisplayName("test_invalid_request_methoduri_in_sink")
+    fun test_invalid_request_methoduri_in_sink() {
+        val sink = LongUriSerializer.instance().deserialize("/test.client/1/test.response")
+        val attributes = UAttributesBuilder.request(UPriority.UPRIORITY_CS0, sink, 3000).build()
+        val validator = UAttributesValidator.getValidator(attributes)
+        assertEquals("UAttributesValidator.Request", validator.toString())
+        val status = validator.validate(attributes)
+        assertEquals(
+            "Invalid RPC method uri. Uri should be the method to be called, or method from response.",
+            status.getMessage()
+        )
+    }
+
+    @Test
+    @DisplayName("test_valid_response_uri_in_sink")
+    fun test_valid_response_uri_in_sink() {
+        val sink = LongUriSerializer.instance().deserialize("/test.client/1/rpc.response")
+        val attributes = UAttributesBuilder.response(
+            UPriority.UPRIORITY_CS0,
+            sink,
+            UuidFactory.Factories.UPROTOCOL.factory().create()
+        ).build()
+        val validator = UAttributesValidator.getValidator(attributes)
+        assertEquals("UAttributesValidator.Response", validator.toString())
+        val status = validator.validate(attributes)
+        assertEquals(ValidationResult.success(), status)
+    }
+
+    @Test
+    @DisplayName("test_invalid_response_uri_in_sink")
+    fun test_invalid_response_uri_in_sink() {
+        val sink = LongUriSerializer.instance().deserialize("/test.client/1/rpc.method")
+        val attributes = UAttributesBuilder.response(
+            UPriority.UPRIORITY_CS0,
+            sink,
+            UuidFactory.Factories.UPROTOCOL.factory().create()
+        ).build()
+        val validator = UAttributesValidator.getValidator(attributes)
+        assertEquals("UAttributesValidator.Response", validator.toString())
+        val status = validator.validate(attributes)
+        assertEquals("Invalid RPC response type.", status.getMessage())
+    }
 
     private fun buildSink(): UUri {
         return uUri {


### PR DESCRIPTION
This commit addresses Issue #7 , where the UAttributesValidator was found to incorrectly handle the sink attribute for RPC request and response messages.